### PR TITLE
s/Auth Token/API Token/, and fix whitespace in publish output

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -24,8 +24,8 @@ fi
 if [ -e credentials.conf ]; then
   source credentials.conf
 else
-  echo -n "Please create a Cloudflare Auth Token with the 'Edit Cloudflare Workers' template."
-  echo -n "Auth Token: "
+  echo "Please create a Cloudflare API Token with Workers Scripts Edit permission on your account (can be created using the Edit Cloudflare Workers API Token template)."
+  echo -n "API Token: "
   read AUTH_TOKEN
   echo -n "Cloudflare account ID (32 hex digits, found on the right sidebar of the Workers dashboard): "
   read ACCOUNT_ID


### PR DESCRIPTION
Previously the "API Token: " message was appended directly onto the
"Please create" message with no space or newline between them.

@greg-mckeon

Changing this in tandem with what's mostly a copy of it in the docs repo - https://github.com/cloudflare/workers-docs-engine/pull/268