### PR TITLE
Replace references to publish.js in chat.mjs

### DIFF
--- a/src/chat.mjs
+++ b/src/chat.mjs
@@ -21,7 +21,11 @@
 // writing regular Workers (without Durable Objects) too, but for now, you must be in the Durable
 // Objects beta to be able to use the new syntax, while we work out the quirks.
 //
-// To see the API for uploading module-based Workers, check out the publish.sh script.
+// To see an example configuration for uploading module-based Workers, check out the wrangler.toml
+// file or one of our Durable Object templates for Wrangler:
+//   * https://github.com/cloudflare/durable-objects-template
+//   * https://github.com/cloudflare/durable-objects-rollup-esm
+//   * https://github.com/cloudflare/durable-objects-webpack-commonjs
 
 // ===============================
 // Required Environment
@@ -40,7 +44,7 @@
 // call into existing code that has different environment requirements, then you need to be able
 // to pass the environment as a parameter instead.
 //
-// Once again, see the publish.sh script to understand how the environment is configured.
+// Once again, see the wrangler.toml file to understand how the environment is configured.
 
 // =======================================================================================
 // The regular Worker part...


### PR DESCRIPTION
Since we've replaced the publish script from the repo with wrangler.

If someone really still wants to use the raw API before we get proper
docs up on api.cloudflare.com, they can either look through Wrangler's
implementation or check out the copy of publish.sh that's still
referenced from the docs:
https://developers.cloudflare.com/workers/learning/using-durable-objects#configuration-script

Fixes #8