### PR TITLE
Use migrations in wrangler.toml rather than ad hoc migrations flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ For more details, take a look at the code! It is well-commented.
 
 If you haven't already, join the Durable Objects beta by visiting the [Cloudflare dashboard](https://dash.cloudflare.com/) and navigating to "Workers" and then "Durable Objects".
 
-Then, make sure you have [Wrangler](https://developers.cloudflare.com/workers/cli-wrangler/install-update), the official Workers CLI, installed. Version 1.17 or newer is required for Durable Objects support.
+Then, make sure you have [Wrangler](https://developers.cloudflare.com/workers/cli-wrangler/install-update), the official Workers CLI, installed. Version 1.19.3 or newer is required to publish this example as written.
 
 After installing it, run `wrangler login` to [connect it to your Cloudflare account](https://developers.cloudflare.com/workers/cli-wrangler/authentication).
 
 Once you're in the Durable Objects beta and have Wrangler installed and authenticated, you can deploy the app for the first time by adding your Cloudflare account ID (which can be viewed by running `wrangler whoami`) to the wrangler.toml file and then running:
 
-    wrangler publish --new-class ChatRoom --new-class RateLimiter
+    wrangler publish
 
-If you get an error about the `--new-class` flag not being recognized, you need to update your version of Wrangler.
+If you get an error saying "Cannot create binding for class [...] because it is not currently configured to implement durable objects", you need to update your version of Wrangler.
 
-This command will deploy the app to your account under the name `edge-chat-demo`. The `--new-class` flags tell Cloudflare that you want the `ChatRoom` and `RateLimiter` classes to be callable as Durable Objects. The flags should be omitted on subsequent uploads of the same Worker because at that point the classes are already configured as Durable Objects.
+This command will deploy the app to your account under the name `edge-chat-demo`.
 
 ## What are the dependencies?
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -15,3 +15,8 @@ bindings = [
   { name = "rooms", class_name = "ChatRoom" },
   { name = "limiters", class_name = "RateLimiter" }
 ]
+
+# Indicate that you want the ChatRoom and RateLimiter classes to be callable as Durable Objects.
+[[migrations]]
+tag = "v1" # Should be unique for each entry
+new_classes = ["ChatRoom", "RateLimiter"]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,7 @@
 name = "edge-chat-demo"
 type = "javascript"
 workers_dev = true
+compatibility_date = "2021-11-08"
 # Add your account ID here
 account_id = ""
 


### PR DESCRIPTION
The downside of this is that `wrangler dev` doesn't yet work alongside
migrations in wrangler.toml so perhaps we want to wait before merging
this, but in general this is the recommended approach going forward.

And add a compatibility date to wrangler.toml while I'm here.

I found it a bit frustrating that I couldn't use the latest dates documented on https://developers.cloudflare.com/workers/platform/compatibility-dates because they're in the future, but that's a small issue. I'll add a note to that page that flags with dates in the future won't be usable until the date is reached.