### PR TITLE
Fixes issue when using wrangler dev

### DIFF
--- a/src/chat.html
+++ b/src/chat.html
@@ -368,7 +368,9 @@ let lastSeenTimestamp = 0;
 let wroteWelcomeMessages = false;
 
 function join() {
-  let ws = new WebSocket("wss://" + hostname + "/api/room/" + roomname + "/websocket");
+  // If we are running via wrangler dev, use ws:
+  const wss = document.location.protocol === "http:" ? "ws://" : "wss://";
+  let ws = new WebSocket(wss + hostname + "/api/room/" + roomname + "/websocket");
   let rejoined = false;
   let startTime = Date.now();
 


### PR DESCRIPTION
When using 'wrangler dev' browser is in http: and should use 'ws:' protocol instead of 'wss:' protocol. Otherwise, the demo fails silently and it's not obvious how it's failing.