### PR TITLE
Added await so the limiter actually limits messages instead of ignoring the Promise

### DIFF
--- a/src/chat.mjs
+++ b/src/chat.mjs
@@ -334,7 +334,7 @@ export class ChatRoom {
       }
 
       // Check if the user is over their rate limit and reject the message if so.
-      if (!await session.limiter.checkLimit()) {
+      if (!(await session.limiter.checkLimit())) {
         webSocket.send(JSON.stringify({
           error: "Your IP is being rate-limited, please try again later."
         }));

--- a/src/chat.mjs
+++ b/src/chat.mjs
@@ -334,7 +334,7 @@ export class ChatRoom {
       }
 
       // Check if the user is over their rate limit and reject the message if so.
-      if (!session.limiter.checkLimit()) {
+      if (!await session.limiter.checkLimit()) {
         webSocket.send(JSON.stringify({
           error: "Your IP is being rate-limited, please try again later."
         }));


### PR DESCRIPTION
This PR fixes the issue where the Rate Limiter not actually limits actually because the Promise is not awaited so the messages are still going through. 