### PR TITLE
Use SQLite as storage

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,7 +6,7 @@ main = "src/chat.mjs"
 [durable_objects]
 bindings = [
   { name = "rooms", class_name = "ChatRoom" },
-  { name = "limiters", class_name = "RateLimiter" }
+  { name = "limiters", class_name = "RateLimiter" },
 ]
 
 [[rules]]
@@ -16,5 +16,5 @@ fallthrough = false
 
 # Indicate that you want the ChatRoom and RateLimiter classes to be callable as Durable Objects.
 [[migrations]]
-tag = "v1" # Should be unique for each entry
-new_classes = ["ChatRoom", "RateLimiter"]
+tag = "v1"                                       # Should be unique for each entry
+new_sqlite_classes = ["ChatRoom", "RateLimiter"]


### PR DESCRIPTION
When deploying this I got an error (below) about using `new_sqlite_classes` with a free plan. So I've updated the wrangler file. According to the docs sqlite is the recommended backend anyway. 

> Cloudflare recommends all new Durable Object namespaces use the [SQLite storage backend](https://developers.cloudflare.com/durable-objects/best-practices/access-durable-objects-storage/#create-sqlite-backed-durable-object-class). These Durable Objects can continue to use storage [key-value API](https://developers.cloudflare.com/durable-objects/api/storage-api/#kv-api). - https://developers.cloudflare.com/durable-objects/api/storage-api/

After deploying the app the chat room works correctly with messages showing up in two different browser instances.

Deploy error:
```
pnpx wrangler deploy

 ⛅️ wrangler 4.24.3
───────────────────
Total Upload: 21.86 KiB / gzip: 6.54 KiB
Your Worker has access to the following bindings:
Binding                         Resource
env.rooms (ChatRoom)            Durable Object
env.limiters (RateLimiter)      Durable Object


✘ [ERROR] A request to the Cloudflare API (/accounts/[redacted]/workers/scripts/edge-chat-demo) failed.

  In order to use Durable Objects with a free plan, you must create a namespace
  using a `new_sqlite_classes` migration. [code: 10097]

  If you think this is a bug, please open an issue at:
  https://github.com/cloudflare/workers-sdk/issues/new/choose
```
